### PR TITLE
update nuget packages

### DIFF
--- a/GameEntityScript/GameEntityScript.csproj
+++ b/GameEntityScript/GameEntityScript.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>D:\Change\To\Your\Path</OutputPath>
+    <OutputPath>F:\entitysync</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AltV.Net" Version="6.0.2" />
+    <PackageReference Include="AltV.Net" Version="8.0.0" />
     <PackageReference Include="AltV.Net.EntitySync" Version="1.13.0" />
-    <PackageReference Include="AltV.Net.EntitySync.ServerEvent" Version="4.0.0" />
+    <PackageReference Include="AltV.Net.EntitySync.ServerEvent" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/GameEntityScript/GameEntityScript.csproj
+++ b/GameEntityScript/GameEntityScript.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>F:\entitysync</OutputPath>
+    <OutputPath>D:\Change\To\Your\Path</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The old `AltV.Net.EntitySync.ServerEvent 4.0.0` depends on `AltV.Net.Async 1.0.0`, which gives a warning `NU1603` on build.